### PR TITLE
add themes for JHEP and JCAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read the [full documentation here](http://www.yxliu.group/MakiePublication.jl/de
 
 ## Features
 
-* Provide a collection of custom themes for journal publishers: ACS, APS, RSC.
+* Provide a collection of custom themes for journal publishers (ACS, APS, RSC) and some individual journals (JCAP, JHEP).
 * Custom theme for making figures suitable for web pages.
 * 15 color palettes based on well-known quality color schemes with special tweaked ordering for scientific publishing. (since v0.3.0)
 * Support hollow markers. (since v0.3.1)
@@ -74,7 +74,7 @@ The demonstration of available color palettes can be found in the Pluto notebook
 
 ## Showcase of Themes
 
-Note that all MakiePublication themes for journal publishers are essentially the same except the physical size of the figure. Hence following figures only different in the image sizes.
+Note that all MakiePublication themes (except `theme_web`) are essentially the same except the physical size of the figure. Hence following figures only different in the image sizes.
 
 - `theme_acs` for American Chemical Society (ACS)
 
@@ -96,5 +96,5 @@ The [full documentation](http://www.yxliu.group/MakiePublication.jl/dev/) is ava
 
 * Star the package on [github.com](https://github.com/liuyxpp/MakiePublication.jl).
 * File an issue or make a pull request on [github.com](https://github.com/liuyxpp/MakiePublication.jl).
-* Pull requests of new schemes for other publishers are highly appreciated.
+* Pull requests of new schemes for other publishers and journals are highly appreciated.
 * Contact the author via email <lyx@fudan.edu.cn>.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-* Provide a collection of custom themes for journal publishers: ACS, APS, RSC.
+* Provide a collection of custom themes for journal publishers (ACS, APS, RSC) and some individual journals (JCAP, JHEP).
 * Custom theme for making figures suitable for web pages.
 * 15 color palettes based on well-known quality color schemes with special tweaked ordering for scientific publishing. (since v0.3.0)
 * Support hollow markers. (since v0.3.1)
@@ -23,7 +23,7 @@ julia> # Press the key "]"
 
 ## Showcase of Themes
 
-Note that all MakiePublication themes for journal publishers are essentially the same except the physical size of the figure. Hence following figures only different in the image sizes.
+Note that all MakiePublication themes (except `theme_web`) are essentially the same except the physical size of the figure. Hence following figures only different in the image sizes.
 
 - `theme_acs` for American Chemical Society (ACS)
 
@@ -45,5 +45,5 @@ Note that all MakiePublication themes for journal publishers are essentially the
 
 * Star the package on [github.com](https://github.com/liuyxpp/MakiePublication.jl).
 * File an issue or make a pull request on [github.com](https://github.com/liuyxpp/MakiePublication.jl).
-* Pull requests of new schemes for other publishers are highly appreciated.
+* Pull requests of new schemes for other publishers and journals are highly appreciated.
 * Contact the author via email <lyx@fudan.edu.cn>.

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -2,7 +2,7 @@
 
 ## Makie Themes
 
-MakiePublication provides 3 Makie themes suitable for creating publication quality figures and 1 theme for web presentation.
+MakiePublication provides 5 Makie themes suitable for creating publication quality figures and 1 theme for web presentation.
 
 ```@docs
 theme_acs
@@ -11,6 +11,8 @@ theme_acs_2col
 theme_aps
 theme_aps_1col
 theme_aps_2col
+theme_jcap
+theme_jhep
 theme_rsc
 theme_rsc_1col
 theme_rsc_2col

--- a/src/MakiePublication.jl
+++ b/src/MakiePublication.jl
@@ -12,7 +12,7 @@ export
     figsize,
     savefig
 
-include("schemes.jl")
+include("themes.jl")
 export
     theme_acs,
     theme_acs_1col,
@@ -20,6 +20,8 @@ export
     theme_aps,
     theme_aps_1col,
     theme_aps_2col,
+    theme_jcap,
+    theme_jhep,
     theme_rsc,
     theme_rsc_1col,
     theme_rsc_2col,

--- a/src/journals.jl
+++ b/src/journals.jl
@@ -1,0 +1,27 @@
+"""
+    theme_jcap(; kwargs...)
+
+Generate Makie theme for producing figures for JCAP (Journal of Cosmology and Astroparticle Physics).
+
+The usage is the same as [`theme_acs`](@ref) except figure `width=6.08948`.
+The value of `width` is obtained from `\\uselengthunit{in}\\printlength{\\linewidth}` and corresponds to 440pt.
+
+JCAP is single column, so `theme_jcap_1col` and `theme_jcap_2col` are not defined.
+
+See also [`theme_acs`](@ref), [`theme_aps`](@ref), [`theme_jhep`](@ref), [`theme_rsc`](@ref), and [`theme_web`](@ref).
+"""
+theme_jcap(; kwargs...) = theme_acs(; width=6.08948, kwargs...)
+
+"""
+    theme_jhep(; kwargs...)
+
+Generate Makie theme for producing figures for JHEP (Journal of High Energy Physics).
+
+The usage is the same as [`theme_acs`](@ref) except figure `width=5.95393`.
+The value of `width` is obtained from `\\uselengthunit{in}\\printlength{\\linewidth}`.
+
+JHEP is single column, so `theme_jhep_1col` and `theme_jhep_2col` are not defined.
+
+See also [`theme_acs`](@ref), [`theme_aps`](@ref), [`theme_jcap`](@ref), [`theme_rsc`](@ref), and [`theme_web`](@ref).
+"""
+theme_jhep(; kwargs...) = theme_acs(; width=5.95393, kwargs...)

--- a/src/schemes.jl
+++ b/src/schemes.jl
@@ -1,4 +1,0 @@
-include("acs.jl")
-include("web.jl")
-include("aps.jl")
-include("rsc.jl")

--- a/src/themes.jl
+++ b/src/themes.jl
@@ -1,0 +1,6 @@
+include("acs.jl")
+include("aps.jl")
+include("rsc.jl")
+include("web.jl")
+
+include("journals.jl")


### PR DESCRIPTION
JHEP (Journal of High Energy Physics) and JCAP (Journal of Cosmology and Astroparticle Physics) are physics journals.

Add figure sizes based on the output of
```
linewidth=\uselengthunit{pt}\printlength{\linewidth}
\\
linewidth=\uselengthunit{in}\printlength{\linewidth}
```

For JHEP these are
```
430.20639pt
5.95393in
```

For JCAP these are
```
440.0pt
6.08948in
```


I did not add example figures to the docs - it wasn't clear if these are generated automattically.