### PR TITLE
test: Add simple tests that themes run

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,54 @@
+name: CI
+on:
+  push:
+    branches:
+      - 'main'
+      - 'ci/*'
+    tags: ['*']
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1' # automatically expands to the latest tagged 1.x release of Julia
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+        include:
+          - os: ubuntu-latest
+            version: 'nightly'
+            arch: x64
+            allow_failure: true # nightly allowed to fail
+          - os: ubuntu-latest
+            version: '1' # automatically expands to the latest tagged 1.x release of Julia
+            arch: x64
+            allow_failure: true # pre-release allowed to fail
+            include-all-prereleases: true # latest tagged version should include prereleases
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,34 @@
+using Documenter
+using Test
+using MakiePublication
+using SafeTestsets
+
+doctest(MakiePublication)
+
+@safetestset "Themes don't error" begin
+    using CairoMakie
+    using MakiePublication
+
+    themes = [
+        theme_acs,
+        theme_acs_1col,
+        theme_acs_2col,
+        theme_aps,
+        theme_aps_1col,
+        theme_aps_2col,
+        theme_jcap,
+        theme_jhep,
+        theme_rsc,
+        theme_rsc_1col,
+        theme_rsc_2col,
+        theme_web
+    ]
+
+    for theme in themes
+        with_theme(theme()) do
+            lines(0..10, sin)
+            lines!(0..10, cos)
+            current_figure()
+        end
+    end
+end


### PR DESCRIPTION
Add some tests using [Julia's standard unit testing](https://docs.julialang.org/en/v1/stdlib/Test/).

These just check that doctests pass and that each theme can be applied to a simple plot.  In principle this could be expanded to check the actual properties of the plots, but that seems like overkill.

Also add a GitHub actions workflow to run tests automatically on pull requests, tags, the branch `main`, and branches matching `ci/*`.