### PR TITLE
fix: `resolution` -> `size`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ MathTeXEngine = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 [compat]
 ColorSchemes = "3.14"
 Colors = "0.12"
-Makie = "0.18, 0.19, 0.20"
+Makie = "0.20"
 MathTeXEngine = "0.5"
 julia = "1.6"

--- a/src/acs.jl
+++ b/src/acs.jl
@@ -162,7 +162,7 @@ function theme_acs(;
         bold_italic=texfont(:bolditalic))
 
     theme_args = (figure_padding=0,
-        resolution=figsize(width, heightwidthratio),
+        size=figsize(width, heightwidthratio),
         colgap=8,
         rowgap=8,
         # font="Helvetica",

--- a/src/web.jl
+++ b/src/web.jl
@@ -120,7 +120,7 @@ function theme_web(;
     palette = isnothing(palette) ? pal : palette
 
     return Theme(#figure_padding=0,
-        resolution=(width, width * heightwidthratio),
+        size=(width, width * heightwidthratio),
         # font="Helvetica",
         palette=palette,
         Axis=axis_theme,

--- a/test/Makie_style.jl
+++ b/test/Makie_style.jl
@@ -94,7 +94,7 @@ function theme_acs(width=3.25, colors=ColorSchemes.glasbey_hv_n256.colors)
 	pal = (color=colors,)
 	
 	return Theme(figure_padding=2,
-				 resolution=figsize(width),
+				 size=figsize(width),
 				 # font="Helvetica",
 				 palette=pal,
 				 Axis=axis_theme,
@@ -171,7 +171,7 @@ function test_color_cycle(colors)
 	newtheme = Theme(figure_padding=2, Scatter=(cycle=Cycle([:color, :marker], covary=true), markersize=7), palette=(color=colors,))
 	set_theme!(newtheme)
 	
-	fig = Figure(resolution=figsize(3.25), font = "Helvetica")
+	fig = Figure(size=figsize(3.25), font = "Helvetica")
 	ax = Axis(fig, xlabel = L"x", ylabel = L"J_{\nu}(x)",
 			  # xlabel="x coord", ylabel="Bessel function",
 			  xlabelsize=9, ylabelsize=9,
@@ -221,7 +221,7 @@ save("test.pdf", fig, pt_per_unit=1.0)
 
 # ╔═╡ b7f1f7c9-4d61-4b1a-b75a-5115d3f286e2
 function default_color_cycle()
-	fig = Figure(resolution = (600,400), font = "Helvetica")
+	fig = Figure(size = (600,400), font = "Helvetica")
 	ax = Axis(fig, xlabel = L"x", ylabel = L"J_{\nu}(x)", ylabelsize = 22, 
 		xlabelsize= 22, xgridstyle=:dash, ygridstyle=:dash, xtickalign = 1, 
 		xticksize=10, ytickalign=1, yticksize=10,  xlabelpadding = -10)


### PR DESCRIPTION
Makie v0.20.0 deprecated the `resolution` argument, replacing it with `size` [1].  This causes Makie to emit deprecation warnings when a theme from MakiePublication is loaded.

Change that argument in MakiePublication too and bump the minimum Makie version to v0.20.0.

[1]: https://github.com/MakieOrg/Makie.jl/releases/tag/v0.20.0