### PR TITLE
add theme for JOSS

### DIFF
--- a/src/MakiePublication.jl
+++ b/src/MakiePublication.jl
@@ -22,6 +22,7 @@ export
     theme_aps_2col,
     theme_jcap,
     theme_jhep,
+    theme_joss,
     theme_rsc,
     theme_rsc_1col,
     theme_rsc_2col,

--- a/src/journals.jl
+++ b/src/journals.jl
@@ -25,3 +25,17 @@ JHEP is single column, so `theme_jhep_1col` and `theme_jhep_2col` are not define
 See also [`theme_acs`](@ref), [`theme_aps`](@ref), [`theme_jcap`](@ref), [`theme_rsc`](@ref), and [`theme_web`](@ref).
 """
 theme_jhep(; kwargs...) = theme_acs(; width=5.95393, kwargs...)
+
+"""
+    theme_joss(; kwargs...)
+
+Generate Makie theme for producing figures for JOSS (The Journal of Open Source Software).
+
+The usage is the same as [`theme_acs`](@ref) except figure `width=5.36066`.
+The value of `width` is obtained from `\\uselengthunit{in}\\printlength{\\linewidth}`.
+
+JOSS is single column, so `theme_joss_1col` and `theme_joss_2col` are not defined.
+
+See also [`theme_acs`](@ref), [`theme_aps`](@ref), [`theme_jcap`](@ref), [`theme_rsc`](@ref), and [`theme_web`](@ref).
+"""
+theme_joss(; kwargs...) = theme_acs(; width=5.36066, kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ doctest(MakiePublication)
         theme_aps_2col,
         theme_jcap,
         theme_jhep,
+        theme_joss,
         theme_rsc,
         theme_rsc_1col,
         theme_rsc_2col,


### PR DESCRIPTION
JOSS (The Journal of Open Source Software) uses a TeX template [1] to compile submissions into PDFs.

Add a MakiePublication theme with figure size based on the output of
```
linewidth=\uselengthunit{pt}\printlength{\linewidth}
\\
linewidth=\uselengthunit{in}\printlength{\linewidth}
```
within a `figure` environment in this template.

The output of this is
```
linewidth=5.36066 in
linewidth=387.33861pt
```

[1]: https://github.com/openjournals/inara/blob/dc6adfd5b65c304154131f3f4fe08aba837677f7/data/templates/default.latex